### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.4",
-    "react": "16.5.0",
+    "react": "~16",
     "react-native": "^0.57.1",
     "react-native-svg": "^7.0.0 || ^8.0.8"
   },


### PR DESCRIPTION
Should be compatible with react's major version unless this project uses unsupported API:s.

Fixes this warning


```
warning " > @fortawesome/react-native-fontawesome@0.1.0" has incorrect peer dependency "react@16.5.0".
```

https://stackoverflow.com/questions/22343224/whats-the-difference-between-tilde-and-caret-in-package-json