### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.4",
     "react": "16.5.0",
-    "react-native": "^0.57.1",
-    "react-native-svg": "^7.0.0 || ^8.0.8"
+    "react-native": "~0",
+    "react-native-svg": "~7 || ~8",
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
@@ -36,9 +36,9 @@
     "babel-jest": "^23.6.0",
     "jest": "^23.6.0",
     "metro-react-native-babel-preset": "^0.48.0",
-    "react": "16.5.0",
-    "react-native": "^0.57.1",
-    "react-native-svg": "^7.0.0 || ^8.0.8",
+    "react": "~16",
+    "react-native": "~0",
+    "react-native-svg": "~7 || ~8",
     "react-test-renderer": "^16.5.2"
   },
   "dependencies": {


### PR DESCRIPTION
It should be possible to use any version of react-native (unless we know otherwise); and they are all `< v1`. Add constraint to that effect in `peerDependencies` to avoid warnings.