### PR TITLE
Add typescript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { IconDefinition } from '@fortawesome/fontawesome-common-types';
+
+declare module '@fortawesome/react-native-fontawesome' {
+  export interface FontAwesomeProps {
+    height?: number;
+    width?: number;
+    size?: number;
+    color?: string;
+    style?: any;
+    icon?: Array<string> | string | IconDefinition;
+    mask?: Array<string> | string | IconDefinition;
+    transform?: string | any;
+  }
+  export class FontAwesomeIcon extends React.Component<FontAwesomeProps> {}
+}


### PR DESCRIPTION
Projects using Typescript are failing to import the library because there is no base level type definition. As there is a `PropType` defined, I just ported it in this PR.

![image](https://user-images.githubusercontent.com/585672/62483661-2686b400-b7b0-11e9-9604-58f62d3aec68.png)
