### PR TITLE
Fix secondaryFill and secondaryOpacity errors by renaming to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,10 +385,10 @@ Note: the `height` and `width` props have been deprecated.
 ### Duotone
 
 ```javascript
-<FontAwesomeIcon icon="coffee" color="blue" secondaryColor="red" secondaryOpacity={ 0.4 } />
+<FontAwesomeIcon icon="coffee" color="blue" secondaryColor="red" secondaryopacity={ 0.4 } />
 ```
 
-You can specify the color and opacity for Duotone's secondary layer using the `secondaryColor` and `secondaryOpacity` props. Note that these are optional, and will simply default to using your primary color at 40% opacity.
+You can specify the color and opacity for Duotone's secondary layer using the `secondaryColor` and `secondaryopacity` props. Note that these are optional, and will simply default to using your primary color at 40% opacity.
 
 ### Masking
 

--- a/dist/components/FontAwesomeIcon.js
+++ b/dist/components/FontAwesomeIcon.js
@@ -100,7 +100,7 @@ function FontAwesomeIcon(props) {
 
   var secondaryColor = props.secondaryColor || null; // Secondary layer opacity should default to 0.4, unless a specific opacity value or a specific secondary color was given
 
-  var secondaryOpacity = props.secondaryOpacity || (secondaryColor ? 1 : DEFAULT_SECONDARY_OPACITY); // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
+  var secondaryopacity = props.secondaryopacity || (secondaryColor ? 1 : DEFAULT_SECONDARY_OPACITY); // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
   // or resolved in other ways, to avoid ambiguity as to which inputs cause which outputs in the underlying rendering process.
   // In other words, we don't want color (for example) to be specified via two different inputs.
 
@@ -127,7 +127,7 @@ function FontAwesomeIcon(props) {
     width: resolvedWidth,
     fill: color,
     secondaryfill: secondaryColor,
-    secondaryOpacity: secondaryOpacity,
+    secondaryopacity: secondaryopacity,
     style: modifiedStyle
   };
   Object.keys(props).forEach(function (key) {
@@ -145,7 +145,7 @@ FontAwesomeIcon.propTypes = {
   size: _propTypes["default"].number,
   color: _propTypes["default"].string,
   secondaryColor: _propTypes["default"].string,
-  secondaryOpacity: _propTypes["default"].number,
+  secondaryopacity: _propTypes["default"].number,
   style: _propTypes["default"].oneOfType([_propTypes["default"].shape({
     style: _propTypes["default"].any
   }), _propTypes["default"].array]),
@@ -160,7 +160,7 @@ FontAwesomeIcon.defaultProps = {
   style: {},
   color: null,
   secondaryColor: null,
-  secondaryOpacity: null,
+  secondaryopacity: null,
   height: undefined,
   width: undefined // Once the deprecation of height and width props is complete, let's put the real default prop value for size here.
   // For now, adding it breaks the default/override logic for height/width/size.

--- a/dist/components/FontAwesomeIcon.js
+++ b/dist/components/FontAwesomeIcon.js
@@ -126,7 +126,7 @@ function FontAwesomeIcon(props) {
     height: resolvedHeight,
     width: resolvedWidth,
     fill: color,
-    secondaryFill: secondaryColor,
+    secondaryfill: secondaryColor,
     secondaryOpacity: secondaryOpacity,
     style: modifiedStyle
   };

--- a/dist/converter.js
+++ b/dist/converter.js
@@ -50,7 +50,7 @@ function convert(createElement, element) {
   var children = (element.children || []).map(function (child, childIndex) {
     var isDuotoneSecondLayer = isDuotone && childIndex === 0;
     var fill = isDuotoneSecondLayer ? extraProps.secondaryfill : extraProps.fill;
-    var fillOpacity = isDuotoneSecondLayer ? extraProps.secondaryOpacity : 1;
+    var fillOpacity = isDuotoneSecondLayer ? extraProps.secondaryopacity : 1;
     return convert(createElement, child, _objectSpread(_objectSpread({}, extraProps), {}, {
       fill: fill,
       fillOpacity: fillOpacity

--- a/dist/converter.js
+++ b/dist/converter.js
@@ -49,7 +49,7 @@ function convert(createElement, element) {
   var isDuotone = (element.children || []).length === 2;
   var children = (element.children || []).map(function (child, childIndex) {
     var isDuotoneSecondLayer = isDuotone && childIndex === 0;
-    var fill = isDuotoneSecondLayer ? extraProps.secondaryFill : extraProps.fill;
+    var fill = isDuotoneSecondLayer ? extraProps.secondaryfill : extraProps.fill;
     var fillOpacity = isDuotoneSecondLayer ? extraProps.secondaryOpacity : 1;
     return convert(createElement, child, _objectSpread(_objectSpread({}, extraProps), {}, {
       fill: fill,

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface Props {
   size?: number;
   color?: string;
   secondaryColor?: string;
-  secondaryOpacity?: number;
+  secondaryopacity?: number;
   mask?: IconProp;
   transform?: string | Transform;
   style?: FontAwesomeIconStyle;

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -72,7 +72,7 @@ export default function FontAwesomeIcon(props) {
   const secondaryColor = props.secondaryColor || null
 
   // Secondary layer opacity should default to 0.4, unless a specific opacity value or a specific secondary color was given
-  const secondaryOpacity = props.secondaryOpacity || (secondaryColor ? 1 : DEFAULT_SECONDARY_OPACITY)
+  const secondaryopacity = props.secondaryopacity || (secondaryColor ? 1 : DEFAULT_SECONDARY_OPACITY)
 
   // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
   // or resolved in other ways, to avoid ambiguity as to which inputs cause which outputs in the underlying rendering process.
@@ -102,7 +102,7 @@ export default function FontAwesomeIcon(props) {
     width: resolvedWidth,
     fill: color,
     secondaryfill: secondaryColor,
-    secondaryOpacity: secondaryOpacity,
+    secondaryopacity: secondaryopacity,
     style: modifiedStyle
   }
 
@@ -129,7 +129,7 @@ FontAwesomeIcon.propTypes = {
 
   secondaryColor: PropTypes.string,
 
-  secondaryOpacity: PropTypes.number,
+  secondaryopacity: PropTypes.number,
 
   style: PropTypes.oneOfType([
     PropTypes.shape({ style: PropTypes.any }),
@@ -158,7 +158,7 @@ FontAwesomeIcon.defaultProps = {
   style: {},
   color: null,
   secondaryColor: null,
-  secondaryOpacity: null,
+  secondaryopacity: null,
   height: undefined,
   width: undefined,
   // Once the deprecation of height and width props is complete, let's put the real default prop value for size here.

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -77,12 +77,12 @@ export default function FontAwesomeIcon(props) {
   // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
   // or resolved in other ways, to avoid ambiguity as to which inputs cause which outputs in the underlying rendering process.
   // In other words, we don't want color (for example) to be specified via two different inputs.
-  const { color: styleColor, ...modifiedStyle} = style
+  const { color: styleColor, ...modifiedStyle } = style
 
   let resolvedHeight, resolvedWidth
 
-  if(height || width){
-    if(size) {
+  if (height || width) {
+    if (size) {
       console.warn(`DEPRECATION: height and width props on ${FontAwesomeIcon.displayName} have been deprecated.  ` +
         `Since you've also provided a size prop, we'll use it to override the height and width props given.  ` +
         `You should probably go ahead and remove the height and width props to avoid confusion and resolve this warning.`)
@@ -101,7 +101,7 @@ export default function FontAwesomeIcon(props) {
     height: resolvedHeight,
     width: resolvedWidth,
     fill: color,
-    secondaryFill: secondaryColor,
+    secondaryfill: secondaryColor,
     secondaryOpacity: secondaryOpacity,
     style: modifiedStyle
   }

--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -86,17 +86,17 @@ function getActualFillColorHex(element) {
 fontawesome.library.add(faCoffee, faCircle)
 
 test.skip('renders with icon specified as array', () => {
-  const tree = renderer.create(<FontAwesomeIcon icon={ ['fas', 'coffee'] } />).toJSON()
+  const tree = renderer.create(<FontAwesomeIcon icon={['fas', 'coffee']} />).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
 test.skip('renders with icon object prop', () => {
-  const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } />).toJSON()
+  const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} />).toJSON()
   expect(tree).toMatchSnapshot()
 })
 
 test.skip('renders with mask and transform', () => {
-  const tree = renderer.create(<FontAwesomeIcon icon={ faCircle } mask={ faCoffee } transform="shrink-9 right-4" />).toJSON()
+  const tree = renderer.create(<FontAwesomeIcon icon={faCircle} mask={faCoffee} transform="shrink-9 right-4" />).toJSON()
   // modify the clipPath and mask identifiers to be fixed, so they aren't regenerated each time and thus
   // our snapshot will remain stable across test runs
   const maskId = "mask-1"
@@ -119,10 +119,10 @@ test.skip('renders with mask and transform', () => {
 })
 
 test.skip('renders transform equivalently when assigning prop as string or object', () => {
-  const firstTree = renderer.create(<FontAwesomeIcon icon={ faCoffee } transform="shrink-9 right-4" />).toJSON()
+  const firstTree = renderer.create(<FontAwesomeIcon icon={faCoffee} transform="shrink-9 right-4" />).toJSON()
   expect(firstTree).toMatchSnapshot()
 
-  const secondTree = renderer.create(<FontAwesomeIcon icon={ faCoffee } transform={fontawesome.parse.transform("shrink-9 right-4")} />).toJSON()
+  const secondTree = renderer.create(<FontAwesomeIcon icon={faCoffee} transform={fontawesome.parse.transform("shrink-9 right-4")} />).toJSON()
   expect(secondTree).toMatchObject(firstTree)
 })
 
@@ -134,7 +134,7 @@ describe('color', () => {
           color: 'blue'
         }
       })
-      const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } style={ styles.icon }/>).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} style={styles.icon} />).toJSON()
       expect(tree.props.fill).toEqual('blue')
       expect(tree.props.style.filter(s => s.color === 'blue').length).toEqual(0)
     })
@@ -146,7 +146,7 @@ describe('color', () => {
             backgroundColor: 'yellow'
           }
         })
-        const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } style={ styles.icon }/>).toJSON()
+        const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} style={styles.icon} />).toJSON()
         expect(tree.props.style.filter(s => s.backgroundColor === 'yellow').length).toEqual(1)
         expect(tree.props.style.filter(s => s.color === 'blue').length).toEqual(0)
       })
@@ -154,7 +154,7 @@ describe('color', () => {
   })
   describe('when color prop is given and NO style.color is given', () => {
     test('renders with color given in color prop', () => {
-      const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } color={ 'purple' }/>).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} color={'purple'} />).toJSON()
       expect(tree.props.fill).toEqual('purple')
       expect(tree.props.tintColor).toBeUndefined()
       const path = tree.children[0].children.find(c => c.type === 'RNSVGPath')
@@ -168,7 +168,7 @@ describe('color', () => {
   })
   describe('when color is specified both by a color prop AND StyleSheet', () => {
     test('color prop overrides style.color', () => {
-      const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } color={ 'blue' } style={{ color: 'red' }}/>).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} color={'blue'} style={{ color: 'red' }} />).toJSON()
       expect(tree.props.fill).toEqual('blue')
       expect(tree.props.tintColor).toBeUndefined()
       const path = tree.children[0].children.find(c => c.type === 'RNSVGPath')
@@ -180,14 +180,14 @@ describe('color', () => {
 describe('size', () => {
   describe('when no size, width, or height props are specified', () => {
     test('default size is assigned', () => {
-      const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } />).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} />).toJSON()
       expect(tree.props.height).toEqual(DEFAULT_SIZE)
       expect(tree.props.width).toEqual(DEFAULT_SIZE)
     })
   })
   describe('when only a size prop is specified', () => {
     test('the given size is assigned', () => {
-      const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } size={ 32 } />).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} size={32} />).toJSON()
       expect(tree.props.height).toEqual(32)
       expect(tree.props.width).toEqual(32)
     })
@@ -199,7 +199,7 @@ describe('size', () => {
 
     const warningListener = warning => {
       const re = new RegExp('^DEPRECATION')
-      if(warning.match(re)) {
+      if (warning.match(re)) {
         warnings.push(warning)
       } else {
         throw new Error(`Unexpected Warning: ${warning}`)
@@ -207,7 +207,7 @@ describe('size', () => {
     }
 
     beforeEach(() => {
-      console.warn = jest.fn( warningListener )
+      console.warn = jest.fn(warningListener)
       warnings.length = 0
     })
 
@@ -217,7 +217,7 @@ describe('size', () => {
 
     describe('when height or width props are specified without a size prop', () => {
       test('the specified height and width are assigned and a deprecation warning is emitted', () => {
-        const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } height={ 32 } width={ 32 } />).toJSON()
+        const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} height={32} width={32} />).toJSON()
         expect(tree.props.height).toEqual(32)
         expect(tree.props.width).toEqual(32)
         expect(warnings.length).toEqual(1)
@@ -226,7 +226,7 @@ describe('size', () => {
 
     describe('when height or width props are specified WITH a size prop', () => {
       test('the size prop overrides the height and width props', () => {
-        const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } size={ 64 } height={ 32 } width={ 32 } />).toJSON()
+        const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} size={64} height={32} width={32} />).toJSON()
         expect(tree.props.height).toEqual(64)
         expect(tree.props.width).toEqual(64)
         expect(warnings.length).toEqual(1)
@@ -237,7 +237,7 @@ describe('size', () => {
 
 describe('when extra props are given', () => {
   test('extra props are passed through to rendered objects', () => {
-    const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } color="purple" foo="bar" />).toJSON()
+    const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} color="purple" foo="bar" />).toJSON()
     expect(tree.props.foo).toEqual("bar")
   })
 })
@@ -259,7 +259,7 @@ describe("convert focusable attribute", () => {
 
 describe('when style is given an array and not an object', () => {
   test('it uses the style objects in array', () => {
-    const tree = renderer.create(<FontAwesomeIcon icon={ faCoffee } style={[{ color: 'red' }, { backgroundColor: 'yellow' }]}/>).toJSON()
+    const tree = renderer.create(<FontAwesomeIcon icon={faCoffee} style={[{ color: 'red' }, { backgroundColor: 'yellow' }]} />).toJSON()
     expect(tree.props.style.filter(s => s.color === 'red').length).toEqual(0)
     expect(tree.props.style.filter(s => s.backgroundColor === 'yellow').length).toEqual(1)
   })
@@ -273,7 +273,7 @@ describe('duotone support', () => {
           color: 'blue'
         }
       })
-      const tree = renderer.create(<FontAwesomeIcon icon={ faAcorn } style={ styles.icon }/>).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faAcorn} style={styles.icon} />).toJSON()
       const primaryLayer = tree.children[0].children[0].children[1]
       const secondaryLayer = tree.children[0].children[0].children[0]
       expect(getActualFillColorHex(primaryLayer)).toEqual(blueHex)
@@ -287,7 +287,7 @@ describe('duotone support', () => {
           color: 'blue'
         }
       })
-      const tree = renderer.create(<FontAwesomeIcon icon={ faAcorn } style={ styles.icon } secondaryOpacity={ 0.123 } />).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faAcorn} style={styles.icon} secondaryopacity={0.123} />).toJSON()
       const primaryLayer = tree.children[0].children[0].children[1]
       const secondaryLayer = tree.children[0].children[0].children[0]
       expect(getActualFillColorHex(primaryLayer)).toEqual(blueHex)
@@ -301,7 +301,7 @@ describe('duotone support', () => {
           color: 'blue'
         }
       })
-      const tree = renderer.create(<FontAwesomeIcon icon={ faAcorn } style={ styles.icon } secondaryColor={ "red" } />).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faAcorn} style={styles.icon} secondaryColor={"red"} />).toJSON()
       const secondaryLayer = tree.children[0].children[0].children[0]
       expect(getActualFillColorHex(secondaryLayer)).toEqual(redHex)
       expect(secondaryLayer.props.fillOpacity).toEqual(1)
@@ -314,7 +314,7 @@ describe('duotone support', () => {
           color: 'blue'
         }
       })
-      const tree = renderer.create(<FontAwesomeIcon icon={ faAcorn } style={ styles.icon } secondaryColor={ "red" } secondaryOpacity={ 0.123 } />).toJSON()
+      const tree = renderer.create(<FontAwesomeIcon icon={faAcorn} style={styles.icon} secondaryColor={"red"} secondaryopacity={0.123} />).toJSON()
       const secondaryLayer = tree.children[0].children[0].children[0]
       expect(getActualFillColorHex(secondaryLayer)).toEqual(redHex)
       expect(secondaryLayer.props.fillOpacity).toEqual(0.123)

--- a/src/converter.js
+++ b/src/converter.js
@@ -23,7 +23,7 @@ function convert(createElement, element, extraProps = {}) {
       const fill = isDuotoneSecondLayer
         ? extraProps.secondaryfill
         : extraProps.fill;
-      const fillOpacity = isDuotoneSecondLayer ? extraProps.secondaryOpacity : 1;
+      const fillOpacity = isDuotoneSecondLayer ? extraProps.secondaryopacity : 1;
       return convert(createElement, child, { ...extraProps, fill, fillOpacity });
     }
   )

--- a/src/converter.js
+++ b/src/converter.js
@@ -21,7 +21,7 @@ function convert(createElement, element, extraProps = {}) {
     (child, childIndex) => {
       const isDuotoneSecondLayer = isDuotone && childIndex === 0;
       const fill = isDuotoneSecondLayer
-        ? extraProps.secondaryFill
+        ? extraProps.secondaryfill
         : extraProps.fill;
       const fillOpacity = isDuotoneSecondLayer ? extraProps.secondaryOpacity : 1;
       return convert(createElement, child, { ...extraProps, fill, fillOpacity });
@@ -42,7 +42,7 @@ function convert(createElement, element, extraProps = {}) {
           acc.attrs[key] = (val === 'true') ? true : false
           break
         default:
-          if (key.indexOf('aria-') === 0 || key.indexOf('data-') === 0 || ( 'fill' === key && 'currentColor' === val )) {
+          if (key.indexOf('aria-') === 0 || key.indexOf('data-') === 0 || ('fill' === key && 'currentColor' === val)) {
             delete element.attributes[key]
           } else {
             acc.attrs[humps.camelize(key)] = val


### PR DESCRIPTION
I was getting a react errors when using this in react-native-web:

```
Warning: React does not recognize the `secondaryFill` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `secondaryfill` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in path (created by Path)
    in Path (created by FontAwesomeIcon)
    in svg (created by Svg)
    in Svg (created by FontAwesomeIcon)
    in FontAwesomeIcon (created by NavButton)
```

```
Warning: React does not recognize the `secondaryOpacity` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `secondaryopacity` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in path (created by Path)
    in Path (created by FontAwesomeIcon)
    in svg (created by Svg)
    in Svg (created by FontAwesomeIcon)
    in FontAwesomeIcon (created by NavButton)
```

I resolved the issue by renaming these as recommended. Tests still pass so I think it's fine?