### PR TITLE
Make possible to use size in percentage

### DIFF
--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -123,7 +123,7 @@ FontAwesomeIcon.propTypes = {
 
   width: PropTypes.number,
 
-  size: PropTypes.number,
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   color: PropTypes.string,
 


### PR DESCRIPTION
Hello.
It is actually works (I can specify size in percentage for react-native-svg component), but emits warning. This PR removes that warning and allows to specify icon size in percentage