### PR TITLE
Add optional testID in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ export interface Props {
   mask?: IconProp;
   transform?: string | Transform;
   style?: FontAwesomeIconStyle;
+  testID?: string;
 }
 
 export function FontAwesomeIcon(props: Props): JSX.Element;


### PR DESCRIPTION
When writing unit or end-to-end tests, we may need to add a testID attribute, especially for non-textual components.

It works well in JS, but TS typings need to know about that optional attribute.