### PR TITLE
Support react-native v0.64.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.4",
-    "react": "~16",
+    "react": ">= 16 < 18",
     "react-native": "> 0.57",
     "react-native-svg": "> 7.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.4",
-    "react": ">= 16 < 18",
+    "react": ">= 16.x",
     "react-native": "> 0.57",
     "react-native-svg": "> 7.0"
   },


### PR DESCRIPTION
Fixes the peer dependancy for `react` so that npm no longer complains about peer dependancies not matching. Unlike #86 it supports older versions of `react-native`.

Tested on `0.64.2` and `0.63.4`.

Uses the same [peer dependancy](https://github.com/FortAwesome/react-fontawesome/blob/8e50c3486922849896d4ff48e45ac92b991e3814/package.json#L52]) as https://github.com/FortAwesome/react-fontawesome

Fixes:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: HelloWorld@0.0.1
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"17.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"~16" from @fortawesome/react-native-fontawesome@0.2.6
npm ERR! node_modules/@fortawesome/react-native-fontawesome
npm ERR!   @fortawesome/react-native-fontawesome@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/mat/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mat/.npm/_logs/2021-07-22T11_37_40_673Z-debug.log
```