### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/__tests__/FontAwesomeIcon.test.js
+++ b/src/components/__tests__/FontAwesomeIcon.test.js
@@ -56,7 +56,7 @@ function rgbToHex(r, g, b) {
 }
 
 function decimalToHex(decimal) {
-  return decimal.toString(16).substr(2, 6);
+  return decimal.toString(16).slice(2, 8);
 }
 
 // react-native-svg changed the way it uses the `fill` attribute across versions. Older versions


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.