### PR TITLE
Update tree-shaking FAQ with destructuring assignment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ If you find that your build times are taking forever, check the way that you are
 In past versions of `react-native-fontawesome` we've documented importing icons like this:
 
 ```javascript
-import faStroopwafel from '@fortawesome/pro-solid-svg-icons'
+import { faStroopwafel } from '@fortawesome/pro-solid-svg-icons'
 ```
 
 This can cause build times for your project to skyrocket because React Native is trying to tree shake. The Font Awesome
@@ -439,7 +439,7 @@ packages are so large that we _highly_ recommend that you avoid this.
 Instead, use "deep imports" by default.
 
 ```javascript
-import faStroopwafel from '@fortawesome/pro-solid-svg-icons/faStroopwafel' // <- notice the additional module here?
+import { faStroopwafel } from '@fortawesome/pro-solid-svg-icons/faStroopwafel' // <- notice the additional module here?
 ```
 
 By directly importing from the `faStroopwafel.js` module there is no additional work that tree shaking needs to do in order to


### PR DESCRIPTION
We're upgrading to Font Awesome v6 and we were looking at common issues in the thread for issue #110. Our project builds in 11 minutes if we use the original import structure. It is reduced to 2 minutes when we use deep imports. 

But one thing I noticed is that neither the top module nor any of the icon modules export these icons by default. They must use the destructuring import syntax. In fact, the other sections in this README use the correct syntax.

I just wanted to correct this section in the README.