### PR TITLE
Use default arguments instead of object spread

### DIFF
--- a/dist/components/FontAwesomeIcon.js
+++ b/dist/components/FontAwesomeIcon.js
@@ -73,48 +73,50 @@ function normalizeIconArgs(icon) {
   }
 }
 
-function FontAwesomeIcon(props) {
-  var _props = _objectSpread({
-    icon: null,
-    mask: null,
-    maskId: null,
-    transform: null,
-    style: {},
-    color: null,
-    secondaryColor: null,
-    secondaryOpacity: null,
-    size: DEFAULT_SIZE
-  }, props);
+function FontAwesomeIcon(_ref2) {
+  var _ref2$icon = _ref2.icon,
+      iconArg = _ref2$icon === void 0 ? null : _ref2$icon,
+      _ref2$mask = _ref2.mask,
+      maskArg = _ref2$mask === void 0 ? null : _ref2$mask,
+      _ref2$maskId = _ref2.maskId,
+      maskId = _ref2$maskId === void 0 ? null : _ref2$maskId,
+      _ref2$transform = _ref2.transform,
+      transformArg = _ref2$transform === void 0 ? null : _ref2$transform,
+      _ref2$style = _ref2.style,
+      styleArg = _ref2$style === void 0 ? {} : _ref2$style,
+      _ref2$color = _ref2.color,
+      colorArg = _ref2$color === void 0 ? null : _ref2$color,
+      _ref2$secondaryColor = _ref2.secondaryColor,
+      secondaryColorArg = _ref2$secondaryColor === void 0 ? null : _ref2$secondaryColor,
+      _ref2$secondaryOpacit = _ref2.secondaryOpacity,
+      secondaryOpacityArg = _ref2$secondaryOpacit === void 0 ? null : _ref2$secondaryOpacit,
+      _ref2$size = _ref2.size,
+      size = _ref2$size === void 0 ? DEFAULT_SIZE : _ref2$size,
+      width = _ref2.width,
+      height = _ref2.height;
 
-  var iconArgs = _props.icon,
-      maskArgs = _props.mask,
-      maskId = _props.maskId,
-      height = _props.height,
-      width = _props.width,
-      size = _props.size;
+  var style = _reactNative.StyleSheet.flatten(styleArg);
 
-  var style = _reactNative.StyleSheet.flatten(_props.style);
-
-  var iconLookup = normalizeIconArgs(iconArgs);
-  var transform = objectWithKey('transform', typeof _props.transform === 'string' ? _fontawesomeSvgCore.parse.transform(_props.transform) : _props.transform);
-  var mask = objectWithKey('mask', normalizeIconArgs(maskArgs));
+  var iconLookup = normalizeIconArgs(iconArg);
+  var transform = objectWithKey('transform', typeof transformArg === 'string' ? _fontawesomeSvgCore.parse.transform(transformArg) : transformArg);
+  var mask = objectWithKey('mask', normalizeIconArgs(maskArg));
   var renderedIcon = (0, _fontawesomeSvgCore.icon)(iconLookup, _objectSpread(_objectSpread(_objectSpread({}, transform), mask), {}, {
     maskId: maskId
   }));
 
   if (!renderedIcon) {
-    (0, _logger["default"])('ERROR: icon not found for icon = ', iconArgs);
+    (0, _logger["default"])('ERROR: icon not found for icon = ', iconArg);
     return null;
   }
 
   var _abstract = renderedIcon["abstract"]; // This is the color that will be passed to the "fill" prop of the Svg element
 
-  var color = _props.color || style.color || DEFAULT_COLOR; // This is the color that will be passed to the "fill" prop of the secondary Path element child (in Duotone Icons)
+  var color = colorArg || style.color || DEFAULT_COLOR; // This is the color that will be passed to the "fill" prop of the secondary Path element child (in Duotone Icons)
   // `null` value will result in using the primary color, at 40% opacity
 
-  var secondaryColor = _props.secondaryColor || color; // Secondary layer opacity should default to 0.4, unless a specific opacity value or a specific secondary color was given
+  var secondaryColor = secondaryColorArg || color; // Secondary layer opacity should default to 0.4, unless a specific opacity value or a specific secondary color was given
 
-  var secondaryOpacity = _props.secondaryOpacity || DEFAULT_SECONDARY_OPACITY; // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
+  var secondaryOpacity = secondaryOpacityArg || DEFAULT_SECONDARY_OPACITY; // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
   // or resolved in other ways, to avoid ambiguity as to which inputs cause which outputs in the underlying rendering process.
   // In other words, we don't want color (for example) to be specified via two different inputs.
 

--- a/src/components/FontAwesomeIcon.js
+++ b/src/components/FontAwesomeIcon.js
@@ -38,31 +38,29 @@ function normalizeIconArgs (icon) {
   }
 }
 
-export default function FontAwesomeIcon (props) {
-  const _props = {
-    icon: null,
-    mask: null,
-    maskId: null,
-    transform: null,
-    style: {},
-    color: null,
-    secondaryColor: null,
-    secondaryOpacity: null,
-    size: DEFAULT_SIZE,
-    ...props
-  };
+export default function FontAwesomeIcon ({
+  icon: iconArg = null,
+  mask: maskArg = null,
+  maskId = null,
+  transform: transformArg = null,
+  style: styleArg = {},
+  color: colorArg = null,
+  secondaryColor: secondaryColorArg = null,
+  secondaryOpacity: secondaryOpacityArg = null,
+  size = DEFAULT_SIZE,
+  width,
+  height
+}) {
+  const style = StyleSheet.flatten(styleArg)
 
-  const { icon: iconArgs, mask: maskArgs, maskId, height, width, size } = _props
-  const style = StyleSheet.flatten(_props.style)
-
-  const iconLookup = normalizeIconArgs(iconArgs)
+  const iconLookup = normalizeIconArgs(iconArg)
   const transform = objectWithKey(
     'transform',
-    typeof _props.transform === 'string'
-      ? parse.transform(_props.transform)
-      : _props.transform
+    typeof transformArg === 'string'
+      ? parse.transform(transformArg)
+      : transformArg
   )
-  const mask = objectWithKey('mask', normalizeIconArgs(maskArgs))
+  const mask = objectWithKey('mask', normalizeIconArgs(maskArg))
 
   const renderedIcon = icon(iconLookup, {
     ...transform,
@@ -71,21 +69,21 @@ export default function FontAwesomeIcon (props) {
   })
 
   if (!renderedIcon) {
-    log('ERROR: icon not found for icon = ', iconArgs)
+    log('ERROR: icon not found for icon = ', iconArg)
     return null
   }
 
   const { abstract } = renderedIcon
 
   // This is the color that will be passed to the "fill" prop of the Svg element
-  const color = _props.color || style.color || DEFAULT_COLOR
+  const color = colorArg || style.color || DEFAULT_COLOR
 
   // This is the color that will be passed to the "fill" prop of the secondary Path element child (in Duotone Icons)
   // `null` value will result in using the primary color, at 40% opacity
-  const secondaryColor = _props.secondaryColor || color
+  const secondaryColor = secondaryColorArg || color
 
   // Secondary layer opacity should default to 0.4, unless a specific opacity value or a specific secondary color was given
-  const secondaryOpacity = _props.secondaryOpacity || DEFAULT_SECONDARY_OPACITY
+  const secondaryOpacity = secondaryOpacityArg || DEFAULT_SECONDARY_OPACITY
 
   // To avoid confusion down the line, we'll remove properties from the StyleSheet, like color, that are being overridden
   // or resolved in other ways, to avoid ambiguity as to which inputs cause which outputs in the underlying rendering process.


### PR DESCRIPTION
This is my attempt at fixing the issue described here: https://github.com/FortAwesome/react-native-fontawesome/pull/171#issuecomment-2123341849

When using object spread, if the last object has an `undefined` attribute, it sets is in the final object.

This was not the behaviour of `defaultProps`, and here is causes a crash when `style={undefined}` is used.

Using default object arguments is the recommended way in modern React, so I switched every prop to it.